### PR TITLE
Create BUILDDIR and BINDIR in Makefile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,3 +4,12 @@ RTI
 The RTI project aims to build an RTI dome.
 
 `Project Documentation <https://cceh.github.io/rti/index.html>`_
+
+Dependencies
+------------
+
+Debian
+
+```shell
+sudo apt install build-essential liblapacke-dev 
+```

--- a/rti-builder/Makefile
+++ b/rti-builder/Makefile
@@ -2,7 +2,6 @@ BUILDDIR = build
 BINDIR = ../bin
 PTMDIR = test-ptms
 IMGDIR = test
-
 CC = gcc -O
 
 CFLAGS = -std=c11 -Wall -Wextra -fopenmp
@@ -16,6 +15,7 @@ all: $(BINDIR)/ptm-decoder $(BINDIR)/ptm-encoder $(BINDIR)/ptm-exploder
 VPATH = o:$(BUILDDIR)
 
 $(BUILDDIR)/%.o : %.c
+	@mkdir -p $(BUILDDIR)
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) $< -o $@
 
 $(BUILDDIR)/ptmlib.o : ptmlib.c ptmlib.h
@@ -27,12 +27,15 @@ $(BUILDDIR)/ptm-encoder.o : ptm-encoder.c ptmlib.h
 $(BUILDDIR)/ptm-exploder.o : ptm-exploder.c ptmlib.h
 
 $(BINDIR)/ptm-decoder: ptm-decoder.o ptmlib.o
+	@mkdir -p $(BINDIR)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 $(BINDIR)/ptm-encoder: ptm-encoder.o ptmlib.o
+	@mkdir -p $(BINDIR)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 $(BINDIR)/ptm-exploder: ptm-exploder.o ptmlib.o
+	@mkdir -p $(BINDIR)
 	$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 PTMS        := $(wildcard $(PTMDIR)/*.ptm)


### PR DESCRIPTION
Hi, thanks for this useful and up-to-date library for RTI!

I had install dependencies (Debian/Ubuntu 19.04) and update the Makefile to create build and bin directories before being able to compile.

Do you plan to support other encodings, e.g. HSH?